### PR TITLE
[FR]update readme file by adding project structure(#28)

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,73 @@ A full-stack Django web application that predicts sneaker prices using machine l
 
 ---
 
+# 📁Project Structure
+
+```bash
+Sneaker-price-prediction/            
+├── github/workflows/                    
+│        └── greetings.yml                 
+├── ThePricePredictionOfsneakersBasedOnMachineLearning//
+│        ├── __pycache__/
+│        ├── __init__.py
+│        ├── asgi.py
+│        ├── settings.py
+│        ├── settings.py
+│        ├── views.py
+│        └── wsgi.py        
+├── admins/
+│     ├── __pycache__/
+│     ├── migrations/
+│     ├── __init__.py
+│     ├── admin.py
+│     ├── apps.py
+│     ├── models.py
+│     ├── tests.py
+│     └── views.py         
+├── media/ 
+│     ├── Clean_Shoe_Data.csv
+│     ├── Explored_Data.csv  
+│     ├── OrderDate_AvgPrice.csv     
+│     ├── Region_AvgPrice.csv    
+│     ├── Sneaker_Name_Avgprice.csv    
+│     └── StockX-Data-Contest-2019-3.csv 
+├── static/assets/
+│     ├── css/
+│     ├──img/ 
+│     ├── js/     
+│     ├── scss/       
+│     └── vendor/
+├── templates/ 
+│     ├── admins/
+│     ├── users/ 
+│     ├── AdminLogin.html   
+│     ├── UserLogin.html   
+│     ├── UserRegistrations.html
+│     ├── base.html  
+│     └── index.html 
+├── users/ 
+│     ├── __pycache__/
+│     ├── migrations/
+│     ├── __init__.py
+│     ├── admin.py
+│     ├── apps.py
+│     ├── forms.py
+│     ├── models.py
+│     ├── tests.py
+│     └── views.py                                            
+├── CODE_OF_CONDUCT.md            
+├── LICENSE                
+├── README.MD                   
+├── db.sqlite3                         
+├── fix-LSTM.ipynb  
+├── manage.py            
+├── requirements.txt                           
+└── settings.py             
+          
+
+```
+---
+
 ## 🛠️ Tech Stack
 
 | Layer         | Tools Used                           |


### PR DESCRIPTION
Issue Title: update readme file by adding project structure

fix #28 

This PR adds a "📁 Project Structure" section to the README.md file to help users and contributors better understand the organization of files and directories in the repository.

Rationale for this change
🔘 Offer a visual representation of the repo layout to aid new contributors in navigating the project faster.

🔘 Reduce onboarding time for developers by making it clear where specific functionality or files are located, which helps prevent confusion when working with the codebase.

🔘 Help contributors understand the purpose of the different files and directories at a glance, making the project more accessible for those unfamiliar with the structure.

While this may have been addressed elsewhere, having a concise project structure section directly in the README helps centralize the information and ensures that it's easily discoverable without requiring the reader to dig through multiple issues or documentation.

# Before (Example with SS)


<img width="837" height="704" alt="Screenshot 2025-08-10 180842" src="https://github.com/user-attachments/assets/65b345ff-b818-4d6b-932e-812628e23e94" />


# After (Example with SS)

<img width="887" height="772" alt="Screenshot 2025-08-10 180851" src="https://github.com/user-attachments/assets/97623d84-ca6a-456d-ab96-8c11ef2bbbea" />

